### PR TITLE
Updated exec-env to use `asdf where lua`

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -3,7 +3,7 @@
 plugin_name="lua"
 
 install_path="$(asdf where lua)"
-full_version="$( echo $install_path | rev | cut -d/ -f1)"
+full_version="$( echo $install_path | rev | cut -d/ -f1 | rev)"
 
 short_lua_version=""
 

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 
-source $(dirname $(dirname $(dirname $0)))/.asdf/lib/utils.sh
-
 plugin_name="lua"
 
-full_version=$(get_preset_version_for $plugin_name)
+install_path="$(asdf where lua)"
+full_version="$( echo $install_path | rev | cut -d/ -f1)"
 
 short_lua_version=""
 
@@ -12,8 +11,6 @@ if [ "$full_version" != "system" ]; then
 	IFS='.' read -r -a splitted_version <<< "$full_version"
 	short_lua_version="${splitted_version[0]}.${splitted_version[1]}"
 fi
-
-install_path="$(get_install_path lua version "${full_version}")"
 
 package_path_override="package.path = package.path .. '\
 ;${install_path}/share/lua/${short_lua_version}/?.lua\


### PR DESCRIPTION
So based on your comments from my earlier pull request I decided to have a go at switching `exec-env` to use `asdf where lua` instead of functions from `utils.sh`. Please feel free to make any changes you see fit.