### PR TITLE
Add support for the `linux-readline` build target (#18)

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -103,6 +103,8 @@ get_target() {
     # If on OSX (Darwin) then the target is macosx
     if [ $os = "Darwin" ]; then
         echo "macosx"
+    elif [ "$ASDF_LUA_LINUX_READLINE" == "1" ]; then
+        echo "linux-readline"
     else # Otherwise we assume Linux
         echo "linux"
     fi


### PR DESCRIPTION
Now you can use the `ASDF_LUA_LINUX_READLINE` environment variable to
install Lua with readline support, like so:

`ASDF_LUA_LINUX_READLINE=1 asdf install lua 5.4.2`

Closes #18.

---

My _very extensive testing_ (/s) showed that it works. I removed the installed Lua versions and plugin, confirmed there was no Lua interpreter available, added this one, installed 5.4.2 with the ENV variable, and it has readline support.