### PR TITLE
Download the latest version of LuaRocks by default, with override

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -66,10 +66,12 @@ install_lua() {
 
         # If we are installing Lua 5.x or greater install LuaRocks as well
         if version_5x_or_greater $version; then
-            echo "Installing LuaRocks..."
-            curl -L 'https://luarocks.org/releases/luarocks-3.1.3.tar.gz' --output luarocks.tar.gz || exit 1
+            local luarocks_version=$(get_latest_luarocks_version)
+            local luarocks_name=luarocks-$luarocks_version
+            echo "Installing LuaRocks v${luarocks_version}..."
+            curl -L "https://luarocks.org/releases/${luarocks_name}.tar.gz" --output luarocks.tar.gz || exit 1
             tar zxpf luarocks.tar.gz || exit 1
-            cd luarocks-3.1.3 || exit 1
+            cd "$luarocks_name" || exit 1
             ./configure --with-lua=$install_path --with-lua-include=$install_path/include --with-lua-lib=$install_path/lib --prefix=$install_path/luarocks || exit 1
             make bootstrap || exit 1
         fi

--- a/bin/install
+++ b/bin/install
@@ -66,7 +66,8 @@ install_lua() {
 
         # If we are installing Lua 5.x or greater install LuaRocks as well
         if version_5x_or_greater $version; then
-            local luarocks_version=$(get_latest_luarocks_version)
+            local luarocks_version
+            luarocks_version=${ASDF_LUA_LUAROCKS_VERSION:-$(get_latest_luarocks_version)}
             local luarocks_name=luarocks-$luarocks_version
             echo "Installing LuaRocks v${luarocks_version}..."
             curl -L "https://luarocks.org/releases/${luarocks_name}.tar.gz" --output luarocks.tar.gz || exit 1

--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -60,3 +60,8 @@ get_download_file_path() {
 
     echo "$tmp_download_dir/$pkg_name"
 }
+
+get_latest_luarocks_version() {
+    curl -sL "https://api.github.com/repos/luarocks/luarocks/tags?per_page=1&page=1" |
+        grep '"name"' | cut -d\" -f4 | cut -c2-
+}


### PR DESCRIPTION
This adds the ability to install the latest version of LuaRocks, by default, and to specify the version explicitly with `ASDF_LUA_LUAROCKS_VERSION`. It would be preferable to use `jq` to parse the version from github's api output, but the included function works fine on both linux and macos.

There may be a good reason (that I'm not aware of) why you have the LuaRocks version hardcoded, like compatibility with a greater range of previous lua versions. 

Either way, consider this a conversation starter.