### PR TITLE
Changing default build platform to "guess"

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -112,8 +112,8 @@ get_target() {
     echo "macosx"
   elif [ "${ASDF_LUA_LINUX_READLINE-}" == "1" ]; then
     echo "linux-readline"
-  else # Otherwise we assume Linux
-    echo "linux"
+  else # Otherwise let the lua Makefile guess for us
+    echo "guess"
   fi
 }
 


### PR DESCRIPTION
The current default guess of `linux` doesn't work on FreeBSD. This PR changes the default platform to `guess`, which allows Lua's make system to infer the platform itself.