### PR TITLE
Recent change broke < v5.4

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -19,6 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        version:
+          - 5.1.5
+          - 5.2.4
+          - 5.3.6
+          - 5.4.6
         os:
           - macos-latest
           - ubuntu-latest
@@ -41,6 +46,7 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v1
         with:
           command: lua -v
+          version: ${{ matrix.version }}
 
   lint:
     runs-on: ubuntu-latest

--- a/bin/install
+++ b/bin/install
@@ -113,7 +113,11 @@ get_target() {
   elif [ "${ASDF_LUA_LINUX_READLINE-}" == "1" ]; then
     echo "linux-readline"
   else # Otherwise let the lua Makefile guess for us
-    echo "guess"
+    if less_than_version_5_4x "$version"; then
+      echo "linux"
+    else
+      echo "guess"
+    fi
   fi
 }
 
@@ -144,6 +148,17 @@ version_5_2x_or_greater() {
   IFS='.' read -ra version_array <<<"$version"
   major_minor_version="${version_array[0]}0${version_array[1]}"
   if (("$major_minor_version" >= 502)); then
+    return 0
+  else
+    return 1
+  fi
+}
+
+less_than_version_5_4x() {
+  version=$1
+  IFS='.' read -ra version_array <<<"$version"
+  major_minor_version="${version_array[0]}0${version_array[1]}"
+  if (("$major_minor_version" < 504)); then
     return 0
   else
     return 1


### PR DESCRIPTION
 - Add version matrix to the tests
 - Fix installation of all version on linux while keeping the freebsd changes for the latest version of lua


https://github.com/nulty/asdf-lua/actions