### PR TITLE
add 5.4.7 as available version

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -23,7 +23,7 @@ jobs:
           - 5.1.5
           - 5.2.4
           - 5.3.6
-          - 5.4.6
+          - 5.4.7
         os:
           - macos-latest
           - ubuntu-latest

--- a/bin/list-all
+++ b/bin/list-all
@@ -44,6 +44,7 @@ versions_list=(
   5.4.4
   5.4.5
   5.4.6
+  5.4.7
 )
 
 versions=""


### PR DESCRIPTION
[5.4.7 was released recently](https://www.lua.org/news.html#2024)