### PR TITLE
fix: use latest release of LuaRocks instead of latest tag

### DIFF
--- a/lib/utils.sh
+++ b/lib/utils.sh
@@ -75,6 +75,6 @@ get_latest_luarocks_version() {
   if [ -n "${GITHUB_API_TOKEN:-}" ]; then
     curl_opts=("${curl_opts[@]}" -H "Authorization: token ${GITHUB_API_TOKEN}")
   fi
-  curl "${curl_opts[@]}" "https://api.github.com/repos/luarocks/luarocks/tags?per_page=1&page=1" |
-    grep '"name"' | cut -d\" -f4 | cut -c2-
+  curl "${curl_opts[@]}" "https://api.github.com/repos/luarocks/luarocks/releases/latest" |
+    grep '"tag_name"' | cut -d\" -f4 | cut -c2-
 }


### PR DESCRIPTION
- The latest *tag* of LuaRocks is 3.13.0, but it's unreleased and has a [bad rockspec file](https://github.com/luarocks/luarocks/issues/1851)
- Instead of using tags, use the latest release. This gets the stable 3.12.2 with a correct rockspec file.
- I'm unable to install Lua 5.1 on macOS without this fix