### PR TITLE
fix rockspec parsing error

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -74,9 +74,12 @@ install_lua() {
       echo "Installing LuaRocks v${luarocks_version}..."
       curl -L "https://luarocks.org/releases/${luarocks_name}.tar.gz" --output luarocks.tar.gz || exit 1
       tar zxpf luarocks.tar.gz || exit 1
-      cd "$luarocks_name" || exit 1
-      ./configure --with-lua="$install_path" --with-lua-include="$install_path/include" --with-lua-lib="$install_path/lib" --prefix="$install_path/luarocks" || exit 1
-      make bootstrap || exit 1
+
+      # clean the environment first and use make install instead of bootstrap to install lua rocks
+      ./configure --with-lua="$install_path" --prefix="$install_path/luarocks" || exit 1
+      make build || exit 1
+      make install || exit 1
+
     fi
   )
 }


### PR DESCRIPTION
Replace `make bootstrap` with `make install` during LuaRocks installation. This bypasses the issue where `make bootstrap` fails to parse the  internal rockspec file using newer Lua interpreters, throwing: '}' expected (to close '{' at line 4) near 'tag'