### PR TITLE
fix: create liblualib.a symlink for Lua 5.1+ installs

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -75,6 +75,15 @@ install_lua() {
       fi
     fi
 
+    # Create liblualib.a -> liblua.a symlink for Lua 5.1+ (liblualib was merged into
+    # liblua in Lua 5.1; gems that still link -llualib will fail without this).
+    # Only created if liblua.a exists and liblualib.a is not already provided.
+    if [ "${lua_type}" != "LuaJIT" ] && version_5_1x_or_greater "$version"; then
+      if [ -f "${install_path}/lib/liblua.a" ] && [ ! -e "${install_path}/lib/liblualib.a" ]; then
+        ln -sf "${install_path}/lib/liblua.a" "${install_path}/lib/liblualib.a"
+      fi
+    fi
+
     # If we are installing Lua 5.x or greater install LuaRocks as well (not for LuaJIT)
     if [ "${lua_type}" != "LuaJIT" ] && version_5x_or_greater "$version"; then
       local luarocks_version


### PR DESCRIPTION
## Problem

Since Lua 5.1, `liblualib` was merged into `liblua`. Lua 5.1+ installs built from source only produce `liblua.a`, but older native extensions (e.g. the `ruby-lua` gem) still link against `-llualib`. This causes the build to fail:

```
ld: library 'lualib' not found
```

## Solution

After copying the Lua files to the install path, create a `liblualib.a → liblua.a` symlink when:

- The version is Lua 5.1 or greater (not LuaJIT — LuaJIT uses different lib naming)
- `liblua.a` is present in the install's `lib/` directory
- `liblualib.a` does not already exist (no-op if a future release ships it again)

```bash
if [ "${lua_type}" != "LuaJIT" ] && version_5_1x_or_greater "$version"; then
  if [ -f "${install_path}/lib/liblua.a" ] && [ ! -e "${install_path}/lib/liblualib.a" ]; then
    ln -sf "${install_path}/lib/liblua.a" "${install_path}/lib/liblualib.a"
  fi
fi
```

This matches what package managers like Homebrew do when installing Lua.